### PR TITLE
add default value to step #81

### DIFF
--- a/alloy_touch.css.js
+++ b/alloy_touch.css.js
@@ -110,7 +110,7 @@
         this.hasMin = !(this.min === void 0);
         this.hasMax = !(this.max === void 0);
         this.isTouchStart = false;
-        this.step = option.step;
+        this.step = this._getValue(option.step, 45);
         this.inertia = this._getValue(option.inertia,true);
         this.maxSpeed = option.maxSpeed;
         this.hasMaxSpeed = !(this.maxSpeed === void 0);


### PR DESCRIPTION
在没有设置step的值的情况下，correction()中计算的result为NaN，导致correction()失效。不知道最科学的默认值是多少，如果不是45的话我再改一下