### PR TITLE
fix: 兼容 matrix2d 值

### DIFF
--- a/alloy_touch.css.js
+++ b/alloy_touch.css.js
@@ -370,7 +370,8 @@
         },
         correction: function () {
             var m_str = window.getComputedStyle(this.scroller)[transform];
-            var value = this.vertical ? parseInt(m_str.split(',')[13]) : parseInt(m_str.split(',')[12]);
+            var m_arr = m_str.split(',');
+            var value = this.vertical ? parseInt(13 in m_arr ? m_arr[13] : m_arr[5]) : parseInt(12 in m_arr ? m_arr[12] : m_arr[4]);
             var rpt = Math.floor(Math.abs(value / this.step));
             var dy = value % this.step;
             var result;


### PR DESCRIPTION
最新版 Chrome 下：

![image](https://user-images.githubusercontent.com/13151189/45259467-58f12b00-b400-11e8-83b3-e261c8e2b587.png)

具体场景是当 css3transform 第二个参数为 true 时，step 不起作用了。

这个 PR 可解决这个问题。