### PR TITLE
fix: 修复引入css3Transform.esm.js的问题

### DIFF
--- a/select/index.js
+++ b/select/index.js
@@ -6,7 +6,9 @@
     var Transform = typeof require === 'function'
         ? require('css3transform')
         : window.Transform
-
+    if (typeof Transform !== 'function') {
+        Transform = Transform.default
+    }
 
     var MSelect = function (option) {
         this.renderTo = typeof option.renderTo === 'string' ? document.querySelector(option.renderTo) : option.renderTo;

--- a/select/package.json
+++ b/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m-select",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Select component for the mobile.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
由于目前`m-select`依赖的`css3transform`已经升级到`1.2.1`，并且在`package.json`中有如下字段：
`  "module": "dist/css3transform.esm.js"`
这使得在引入Transform的时候会引入esm模块，如果直接引入`css3Transform`
`var Transform = require('css3Transform')`
打印出来的模块如下
![image](https://user-images.githubusercontent.com/14247110/48690533-ed021e80-ec09-11e8-9677-94e50232c74d.png)
因此需要判断是否是引入了esm模块，如果是，需要将`default`模块赋值给它，才能使得`m-select`正常运作。