### PR TITLE
Fix_偶尔会出现change事件参数为NaN的问题

### DIFF
--- a/alloy_touch.js
+++ b/alloy_touch.js
@@ -233,7 +233,7 @@
                     }.bind(this));
                 } else if (this.inertia && !triggerTap && !this._preventMove) {
                     var dt = new Date().getTime() - this.startTime;
-                    if (dt < 300) {
+                    if (dt < 300 && dt > 0) {
                         var distance = ((this.vertical ? evt.changedTouches[0].pageY : evt.changedTouches[0].pageX) - this.start) * this.sensitivity,
                             speed = Math.abs(distance) / dt,
                             speed2 = this.factor * speed;


### PR DESCRIPTION
问题描述：
偶尔会出现change事件参数为NaN，且后续一直都为NaN。

发生原因：
_end 事件中的dt有时候会为0（通过打印得知，具体原因未知），导致后续计算错误。

修改代码位置：
236行